### PR TITLE
Weaker song comparison

### DIFF
--- a/src/main/java/chart/ChartEntry.java
+++ b/src/main/java/chart/ChartEntry.java
@@ -28,4 +28,10 @@ public interface ChartEntry {
                             .artist(artist())
                             .build();
     }
+
+    default boolean sameSongAs(SimpleChartEntry entry) {
+        return id().equalsIgnoreCase(entry.id())
+                || (artist().equalsIgnoreCase(entry.artist())
+                && title().equalsIgnoreCase(entry.title()));
+    }
 }

--- a/src/main/java/chart/postgres/PostgresChartCompiler.java
+++ b/src/main/java/chart/postgres/PostgresChartCompiler.java
@@ -103,8 +103,7 @@ public class PostgresChartCompiler implements ChartCompiler<SpotifyChart> {
     }
 
     private Predicate<ChartEntry> sameSongAs(SimpleChartEntry entry) {
-        return sce -> sce.artist().equalsIgnoreCase(entry.artist())
-                && sce.title().equalsIgnoreCase(entry.title());
+        return sce -> sce.sameSongAs(entry);
     }
 
     private SpotifyChart allNewEntries(SimpleSpotifyChart thisWeek) {

--- a/src/test/java/chart/spotify/SpotifyChartEntryTest.java
+++ b/src/test/java/chart/spotify/SpotifyChartEntryTest.java
@@ -1,11 +1,13 @@
 package chart.spotify;
 
 import chart.ChartTestUtils;
+import chart.SimpleChartEntry;
 import com.wrapper.spotify.models.Track;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class SpotifyChartEntryTest {
     private static final int POSITION = 1;
@@ -60,5 +62,41 @@ public class SpotifyChartEntryTest {
                 .track(trackWithDifferentUri)
                 .build();
         assertNotEquals("uri should have been different", canonical, differentHref);
+    }
+
+    @Test
+    public void same_id_means_same_song() {
+        Track trackWithDifferentTitle = ChartTestUtils.track();
+        trackWithDifferentTitle.setName(trackWithDifferentTitle.getName() + " (Radio Edit)");
+        SpotifyChartEntry differentTitle = ImmutableSpotifyChartEntry.builder()
+                .from(canonical)
+                .track(trackWithDifferentTitle)
+                .build();
+
+        SimpleChartEntry sce = ImmutableSimpleSpotifyChartEntry.builder()
+                .track(canonical.track())
+                .position(5)
+                .build();
+
+        assertTrue("Expected " + differentTitle + " to have the same song as " + sce,
+                differentTitle.sameSongAs(sce));
+    }
+
+    @Test
+    public void same_artist_and_title_means_same_song() {
+        Track trackWithDifferentId = ChartTestUtils.track();
+        trackWithDifferentId.setId("different-id");
+        SpotifyChartEntry differentId = ImmutableSpotifyChartEntry.builder()
+                .from(canonical)
+                .track(trackWithDifferentId)
+                .build();
+
+        SimpleChartEntry sce = ImmutableSimpleSpotifyChartEntry.builder()
+                .track(canonical.track())
+                .position(5)
+                .build();
+
+        assertTrue("Expected " + differentId + " to have the same song as " + sce,
+                differentId.sameSongAs(sce));
     }
 }


### PR DESCRIPTION
Spotify tracks sometimes have edits to their title/artist while keeping the same ID. This stops them from being treated as new entries when that happens.